### PR TITLE
Fix for issue #1. Non-latest versions can now be retained

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ appropriate switches as provided below.
       Comma separated list of groupIds (full or part) to be ignored.
     --path, -p
       Path to m2 directory, if using a custom path.
+    --retainOld, -ro
+      Retain the artifacts even if old versions. Only process the configured inputs.
+      Default: false
       
 
 Feel free to raise any issues or recommend any changes or improvements.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.github.techpavan</groupId>
     <artifactId>mvn-repo-cleaner</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
 
     <dependencies>
         <dependency>

--- a/src/main/java/com/github/techpavan/maven/ArgData.java
+++ b/src/main/java/com/github/techpavan/maven/ArgData.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import org.apache.commons.lang3.time.DateUtils;
 
 import java.text.ParseException;
-import java.util.Arrays;
 import java.util.List;
 
 @Data
@@ -50,6 +49,9 @@ public class ArgData {
 
     @Parameter(names = {"--dryrun", "-dr"}, description = "Do not delete files, just simulate and print result.")
     private boolean dryRun;
+
+    @Parameter(names = {"--retainOld", "-ro"}, description = "Retain the artifacts even if old versions. Only process the configured inputs.")
+    private boolean retainOld;
 
     static class DateToMillisConverter implements IStringConverter<Long> {
 

--- a/src/main/java/com/github/techpavan/maven/CleanM2.java
+++ b/src/main/java/com/github/techpavan/maven/CleanM2.java
@@ -49,6 +49,7 @@ public class CleanM2 {
         SKIP_MAP.put(SkipReason.RESERVED, new HashSet<>());
         SKIP_MAP.put(SkipReason.IGNORED_ARTIFACT, new HashSet<>());
         SKIP_MAP.put(SkipReason.IGNORED_GROUP, new HashSet<>());
+        SKIP_MAP.put(SkipReason.RETAIN_OLD, new HashSet<>());
         SKIP_MAP.put(SkipReason.LATEST, new HashSet<>());
     }
 
@@ -157,6 +158,10 @@ public class CleanM2 {
                 DELETE_MAP.get(DeleteReason.DOWNLOAD_DATE).add(file.getParentFile());
                 return;
             }
+            if (argData.isRetainOld()) {
+                SKIP_MAP.get(SkipReason.RETAIN_OLD).add(file.getParentFile().getAbsolutePath());
+                return;
+            }
             // When none of the above are matched, add it for latest / oldest processing
             addToProcessMap(fileInfo);
         } catch (IOException e) {
@@ -199,7 +204,6 @@ public class CleanM2 {
         fileInfo.setFile(file);
         fileInfo.setArtifactId(findArtifactId(file));
         fileInfo.setGroupId(findGroupId(file, fileInfo.getArtifactId()));
-        String gaId = fileInfo.getGroupId() + ":" + fileInfo.getArtifactId();
         fileInfo.setVersion(findVersion(file));
         return fileInfo;
     }
@@ -240,7 +244,7 @@ public class CleanM2 {
     }
 
     private enum SkipReason {
-        IGNORED_ARTIFACT, IGNORED_GROUP, LATEST, RESERVED
+        IGNORED_ARTIFACT, IGNORED_GROUP, LATEST, RESERVED, RETAIN_OLD
     }
 
 }


### PR DESCRIPTION
Non-latest versions can now be retained using the option --retainOld. This option is false by default and the default execution from shell / batch scripts will remove the old versions of all artifacts.