### PR TITLE
Fix custom directory logic handling (#10), other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target/
+.classpath
+.project
+.settings/
+dependency-reduced-pom.xml

--- a/README.md
+++ b/README.md
@@ -4,20 +4,19 @@
 As newer versions of dependent libraries appear, the old ones become obsolete 
 and never get cleaned up. 
 This program assists to free up some disk space by removing older versions of 
-libraries downloaded to the `.m2` directory.
+libraries downloaded to the local Maven repository.
 
 This can be used just by extracting `mvn-repo-cleaner.tar.gz` / `mvn-repo-cleaner.zip` 
 and executing the `execute.sh` / `execute.bat` as per the environment 
-to clean up all non-latest versions of the libraries in the `.m2` directory.
+to clean up all non-latest versions of the libraries in the `<user_dir>/.m2/repository` directory.
+
+If the local repository is in a different location, use the `--path` flag to specify its location.
 
 To attempt a `dry-run`, just execute the `simulate.sh` / `simulate.bat` 
 to see the files that would be removed without actually deleting the files.
 This output is also generated in the `mvn-repo-cleaner.log`.
 
-To run with more advanced options, open the terminal and execute the jar with 
-appropriate switches as provided below.
-
-**NOTE:** When using the `--path/-p` option, the target it points to must contain a directory (or symlink) called *repository*. This might be needed when cleaning a local directory used for publishing.
+To run with more advanced options, run the `execute` script with the flags below.
 
 `Usage: java -jar mvn-repo-cleaner.jar [options]`
 
@@ -58,7 +57,7 @@ appropriate switches as provided below.
     --ignoreGroups, -ig
       Comma separated list of groupIds (full or part) to be ignored.
     --path, -p
-      Path to m2 directory, if using a custom path.
+      Path to local Maven repository if not in <user_dir>/.m2/repository.
     --retainOld, -ro
       Retain the artifacts even if old versions. Only process the configured inputs.
       Default: false

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.github.techpavan</groupId>
     <artifactId>mvn-repo-cleaner</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 
     <dependencies>
         <dependency>

--- a/src/assembly/scripts/execute.bat
+++ b/src/assembly/scripts/execute.bat
@@ -1,1 +1,1 @@
-java -jar mvn-repo-cleaner.jar
+java -jar mvn-repo-cleaner.jar %*

--- a/src/assembly/scripts/execute.sh
+++ b/src/assembly/scripts/execute.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-java -jar mvn-repo-cleaner.jar
+java -jar mvn-repo-cleaner.jar "$@"

--- a/src/assembly/scripts/simulate.bat
+++ b/src/assembly/scripts/simulate.bat
@@ -1,1 +1,1 @@
-java -jar mvn-repo-cleaner.jar -dr
+java -jar mvn-repo-cleaner.jar -dr %*

--- a/src/assembly/scripts/simulate.sh
+++ b/src/assembly/scripts/simulate.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-java -jar mvn-repo-cleaner.jar -dr
+java -jar mvn-repo-cleaner.jar -dr "$@"

--- a/src/main/java/com/github/techpavan/maven/ArgData.java
+++ b/src/main/java/com/github/techpavan/maven/ArgData.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Data
 public class ArgData {
 
-    @Parameter(names = {"--path", "-p"}, description = "Path to m2 directory, if using a custom path.")
+    @Parameter(names = {"--path", "-p"}, description = "Path to local Maven repository if not in <user_dir>/.m2/repository.")
     private String m2Path;
 
     @Parameter(names = {"--downloadedBefore", "-db"}, description = "Delete all libraries (even if latest version) downloaded on or before this date (MM-DD-YYYY).", converter = DateToMillisConverter.class)

--- a/src/main/java/com/github/techpavan/maven/CleanM2.java
+++ b/src/main/java/com/github/techpavan/maven/CleanM2.java
@@ -75,15 +75,14 @@ public class CleanM2 {
     }
 
     private static File evaluateM2Path(JCommander jCommander) {
-        String m2Path = defaultString(argData.getM2Path(), concat(USER_HOME, ".m2"));
+        String m2Path = defaultString(argData.getM2Path(), concat(concat(USER_HOME, ".m2"), "repository"));
         File m2Dir = new File(m2Path);
-        File repoDir = new File(m2Path, "repository");
-        if (!m2Dir.exists() || !repoDir.exists()) {
+        if (!m2Dir.exists()) {
             log.error("Valid Maven repository could not be found. Please provide a valid input.");
             jCommander.usage();
             System.exit(1);
         }
-        return repoDir;
+        return m2Dir;
     }
 
     private static JCommander parseInputParams(String[] args) {


### PR DESCRIPTION
- Make it so the directory specified by `--path` doesn't _have_ to end in `repository` as this is counterintuitive (see #10)
- Add .gitignore so generated files aren't committed
- Allow passing of command line arguments to the `execute` scripts